### PR TITLE
Added reset parameters to select the visual themes if the theme order is set to random

### DIFF
--- a/Assets/ObstacleTower/Scenes/Procedural.unity
+++ b/Assets/ObstacleTower/Scenes/Procedural.unity
@@ -911,6 +911,22 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   floor: {fileID: 883513242}
   InferenceOn: 0
+  towerSeed: -1
+  startingFloor: 0
+  totalFloors: 100
+  denseReward: 1
+  lightingType: 1
+  visualTheme: 1
+  agentPerspective: 1
+  allowedRooms: 2
+  allowedModules: 2
+  allowedFloors: 2
+  defaultTheme: 0
+  useAncient: 1
+  useMoorish: 1
+  useIndustrial: 1
+  useModern: 1
+  useFuture: 1
 --- !u!4 &1774455169
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/ObstacleTower/Scripts/AgentLogic/EnvironmentParameters.cs
+++ b/Assets/ObstacleTower/Scripts/AgentLogic/EnvironmentParameters.cs
@@ -15,6 +15,7 @@ public struct EnvironmentParameters
     public AllowedRoomTypes allowedRoomTypes;
     public AllowedFloorLayouts allowedFloorLayouts;
     public VisualTheme defaultTheme;
+    public bool use_ancient, use_moorish, use_industrial, use_modern, use_future;
 
     public bool Compare(EnvironmentParameters otherParams)
     {
@@ -24,7 +25,12 @@ public struct EnvironmentParameters
                         allowedRoomModules == otherParams.allowedRoomModules &&
                         allowedRoomTypes == otherParams.allowedRoomTypes &&
                         allowedFloorLayouts == otherParams.allowedFloorLayouts &&
-                        defaultTheme == otherParams.defaultTheme;
+                        defaultTheme == otherParams.defaultTheme &&
+                        use_ancient == otherParams.use_ancient &&
+                        use_moorish == otherParams.use_moorish &&
+                        use_industrial == otherParams.use_industrial &&
+                        use_modern == otherParams.use_modern &&
+                        use_future == otherParams.use_future;
         return equality;
     }
 }

--- a/Assets/ObstacleTower/Scripts/AgentLogic/ObstacleTowerManager.cs
+++ b/Assets/ObstacleTower/Scripts/AgentLogic/ObstacleTowerManager.cs
@@ -53,6 +53,11 @@ public class ObstacleTowerManager : MonoBehaviour
         floor.environmentParameters.allowedRoomModules = AllowedRoomModules.All;
         floor.environmentParameters.allowedFloorLayouts = AllowedFloorLayouts.PlusCircling;
         floor.environmentParameters.defaultTheme = VisualTheme.Ancient;
+        floor.environmentParameters.use_ancient = true;
+        floor.environmentParameters.use_moorish = true;
+        floor.environmentParameters.use_industrial = true;
+        floor.environmentParameters.use_modern = true;
+        floor.environmentParameters.use_future = true;
     }
 
     private void UpdateEnvironmentParameters()
@@ -71,6 +76,14 @@ public class ObstacleTowerManager : MonoBehaviour
         if (Enum.IsDefined(typeof(VisualThemeParameter), visTheme))
         {
             floor.environmentParameters.themeParameter = (VisualThemeParameter) visTheme;
+            if (floor.environmentParameters.themeParameter.Equals(VisualThemeParameter.Random))
+            {
+                floor.environmentParameters.use_ancient = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-ancient", 1.0f));
+                floor.environmentParameters.use_moorish = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-moorish", 1.0f));
+                floor.environmentParameters.use_industrial = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-industrial", 1.0f));
+                floor.environmentParameters.use_modern = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-modern", 1.0f));
+                floor.environmentParameters.use_future = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-future", 1.0f));
+            }
         }
         else
         {

--- a/Assets/ObstacleTower/Scripts/AgentLogic/ObstacleTowerManager.cs
+++ b/Assets/ObstacleTower/Scripts/AgentLogic/ObstacleTowerManager.cs
@@ -20,7 +20,29 @@ public class ObstacleTowerManager : MonoBehaviour
     public bool InferenceOn = false;
 
     private ObstacleTowerAgent agentComponent;
-    
+
+    [Header("Default Reset Parameters")]
+    [Range(-1, MaxSeed)]
+    public int towerSeed = -1;
+    [Range(0,99)]
+    public int startingFloor = 0;
+    [Range(1,100)]
+    public int totalFloors = 100;
+    public bool denseReward = true;
+    public LightingType lightingType = LightingType.Dynamic;
+    public VisualThemeParameter visualTheme = VisualThemeParameter.Serial;
+    public AgentPerspective agentPerspective = AgentPerspective.ThirdPerson;
+    public AllowedRoomTypes allowedRooms = AllowedRoomTypes.PlusPuzzle;
+    public AllowedRoomModules allowedModules = AllowedRoomModules.All;
+    public AllowedFloorLayouts allowedFloors = AllowedFloorLayouts.PlusCircling;
+    public VisualTheme defaultTheme = VisualTheme.Ancient;
+    [Header("Toogle single visual themes if Visual Theme is set to Random.")]
+    public bool useAncient = true;
+    public bool useMoorish = true;
+    public bool useIndustrial = true;
+    public bool useModern = true;
+    public bool useFuture = true;
+
     public void Awake()
     {
         floor.environmentParameters = new EnvironmentParameters();
@@ -62,7 +84,7 @@ public class ObstacleTowerManager : MonoBehaviour
 
     private void UpdateEnvironmentParameters()
     {
-        var lightType = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("lighting-type", (int)LightingType.Dynamic);
+        var lightType = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("lighting-type", (int)lightingType);
         if (Enum.IsDefined(typeof(LightingType), lightType))
         {
             floor.environmentParameters.lightingType = (LightingType) lightType;
@@ -72,17 +94,22 @@ public class ObstacleTowerManager : MonoBehaviour
             Debug.Log("lighting-type outside of valid range. Using default value.");
         }
 
-        var visTheme = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("visual-theme", (int)VisualThemeParameter.Serial);
+        var visTheme = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("visual-theme", (int)visualTheme);
         if (Enum.IsDefined(typeof(VisualThemeParameter), visTheme))
         {
             floor.environmentParameters.themeParameter = (VisualThemeParameter) visTheme;
             if (floor.environmentParameters.themeParameter.Equals(VisualThemeParameter.Random))
             {
-                floor.environmentParameters.use_ancient = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-ancient", 1.0f));
-                floor.environmentParameters.use_moorish = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-moorish", 1.0f));
-                floor.environmentParameters.use_industrial = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-industrial", 1.0f));
-                floor.environmentParameters.use_modern = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-modern", 1.0f));
-                floor.environmentParameters.use_future = Convert.ToBoolean(Academy.Instance.EnvironmentParameters.GetWithDefault("use-future", 1.0f));
+                floor.environmentParameters.use_ancient = Convert.ToBoolean(
+                    Academy.Instance.EnvironmentParameters.GetWithDefault("use-ancient", Convert.ToSingle(useAncient)));
+                floor.environmentParameters.use_moorish = Convert.ToBoolean(
+                    Academy.Instance.EnvironmentParameters.GetWithDefault("use-moorish", Convert.ToSingle(useMoorish)));
+                floor.environmentParameters.use_industrial = Convert.ToBoolean(
+                    Academy.Instance.EnvironmentParameters.GetWithDefault("use-industrial", Convert.ToSingle(useIndustrial)));
+                floor.environmentParameters.use_modern = Convert.ToBoolean(
+                    Academy.Instance.EnvironmentParameters.GetWithDefault("use-modern", Convert.ToSingle(useModern)));
+                floor.environmentParameters.use_future = Convert.ToBoolean(
+                    Academy.Instance.EnvironmentParameters.GetWithDefault("use-future", Convert.ToSingle(useFuture)));
             }
         }
         else
@@ -90,7 +117,7 @@ public class ObstacleTowerManager : MonoBehaviour
             Debug.Log("visual-theme outside of valid range. Using default value.");
         }
         
-        var perspective = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("agent-perspective", (int)AgentPerspective.ThirdPerson);
+        var perspective = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("agent-perspective", (int)agentPerspective);
         if (Enum.IsDefined(typeof(AgentPerspective), perspective))
         {
             floor.environmentParameters.agentPerspective = (AgentPerspective) perspective;
@@ -100,40 +127,40 @@ public class ObstacleTowerManager : MonoBehaviour
             Debug.Log("agent-perspective outside of valid range. Using default value.");
         }
         
-        var allowedRooms = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("allowed-rooms", (int)AllowedRoomTypes.PlusPuzzle);
-        if (Enum.IsDefined(typeof(AllowedRoomTypes), allowedRooms))
+        var allowedRoomTypes = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("allowed-rooms", (int)allowedRooms);
+        if (Enum.IsDefined(typeof(AllowedRoomTypes), allowedRoomTypes))
         {
-            floor.environmentParameters.allowedRoomTypes = (AllowedRoomTypes) allowedRooms;
+            floor.environmentParameters.allowedRoomTypes = (AllowedRoomTypes) allowedRoomTypes;
         }
         else
         {
             Debug.Log("allowed-rooms outside of valid range. Using default value.");
         }
         
-        var allowedModules = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("allowed-modules", (int)AllowedRoomModules.All);
-        if (Enum.IsDefined(typeof(AllowedRoomModules), allowedModules))
+        var allowedRoomModules = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("allowed-modules", (int)allowedModules);
+        if (Enum.IsDefined(typeof(AllowedRoomModules), allowedRoomModules))
         {
-            floor.environmentParameters.allowedRoomModules = (AllowedRoomModules) allowedModules;
+            floor.environmentParameters.allowedRoomModules = (AllowedRoomModules) allowedRoomModules;
         }
         else
         {
             Debug.Log("allowed-modules outside of valid range. Using default value.");
         }
         
-        var allowedFloors = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("allowed-floors", (int)AllowedFloorLayouts.PlusCircling);
-        if (Enum.IsDefined(typeof(AllowedFloorLayouts), allowedFloors))
+        var allowedFloorLayouts = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("allowed-floors", (int)allowedFloors);
+        if (Enum.IsDefined(typeof(AllowedFloorLayouts), allowedFloorLayouts))
         {
-            floor.environmentParameters.allowedFloorLayouts = (AllowedFloorLayouts) allowedFloors;
+            floor.environmentParameters.allowedFloorLayouts = (AllowedFloorLayouts)allowedFloorLayouts;
         }
         else
         {
             Debug.Log("allowed-floors outside of valid range. Using default value.");
         }
         
-        var defaultTheme = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("default-theme", (int)VisualTheme.Ancient);
-        if (Enum.IsDefined(typeof(VisualTheme), defaultTheme))
+        var defaultVisualTheme = (int)Academy.Instance.EnvironmentParameters.GetWithDefault("default-theme", (int)defaultTheme);
+        if (Enum.IsDefined(typeof(VisualTheme), defaultVisualTheme))
         {
-            floor.environmentParameters.defaultTheme = (VisualTheme) defaultTheme;
+            floor.environmentParameters.defaultTheme = (VisualTheme)defaultVisualTheme;
         }
         else
         {
@@ -144,7 +171,7 @@ public class ObstacleTowerManager : MonoBehaviour
     public void ResetTower()
     {
         Debug.Log("Tower resetting");
-        agentComponent.denseReward = Mathf.Clamp((int) Academy.Instance.EnvironmentParameters.GetWithDefault("dense-reward",0), 0, 1) != 0;
+        agentComponent.denseReward = Mathf.Clamp((int)Academy.Instance.EnvironmentParameters.GetWithDefault("dense-reward", Convert.ToInt32(denseReward)), 0, 1) != 0;
         if (InferenceOn)
         {
             EnableInference();
@@ -154,26 +181,26 @@ public class ObstacleTowerManager : MonoBehaviour
             EnableTraining();
         }
         
-        var towerSeed = Mathf.Clamp((int) Academy.Instance.EnvironmentParameters.GetWithDefault("tower-seed",-1), -1, MaxSeed);
-        var totalFloors = Mathf.Clamp((int) Academy.Instance.EnvironmentParameters.GetWithDefault("total-floors", MaxFloors), 1, MaxFloors);
-        var startingFloor = Mathf.Clamp((int) Academy.Instance.EnvironmentParameters.GetWithDefault("starting-floor",0), 0, totalFloors);
+        var seed = Mathf.Clamp((int)Academy.Instance.EnvironmentParameters.GetWithDefault("tower-seed", towerSeed), -1, MaxSeed);
+        var floors = Mathf.Clamp((int)Academy.Instance.EnvironmentParameters.GetWithDefault("total-floors", totalFloors), 1, MaxFloors);
+        var start = Mathf.Clamp((int)Academy.Instance.EnvironmentParameters.GetWithDefault("starting-floor", startingFloor), 0, floors);
         
         UpdateEnvironmentParameters();
         
-        if (totalFloors > 0 && totalFloors < MaxFloors)
+        if (floors > 0 && floors < MaxFloors)
         {
-            floor.totalFloors = totalFloors;
+            floor.totalFloors = floors;
         }
-        if (startingFloor < floor.totalFloors && startingFloor >= 0)
+        if (start < floor.totalFloors && start >= 0)
         {
-            floor.startingFloorNumber = startingFloor;
+            floor.startingFloorNumber = start;
         }
 
-        bool validSeed = towerSeed < MaxSeed;
-        if (towerSeed != -1 && validSeed)
+        bool validSeed = seed < MaxSeed;
+        if (seed != -1 && validSeed)
         {
             floor.fixedTower = true;
-            floor.towerNumber = towerSeed;
+            floor.towerNumber = seed;
         }
         else
         {

--- a/Assets/ObstacleTower/Scripts/FloorLogic/FloorGenerator.cs
+++ b/Assets/ObstacleTower/Scripts/FloorLogic/FloorGenerator.cs
@@ -5,6 +5,7 @@ using Random = UnityEngine.Random;
 using ObstacleTowerGeneration;
 using ObstacleTowerGeneration.LayoutGrammar;
 using ObstacleTowerGeneration.MissionGraph;
+using System.Linq;
 
 /// <summary>
 /// Responsible for generating floor layouts based on environment parameters.
@@ -268,12 +269,22 @@ public class FloorGenerator
 
                 return VisualTheme.Future;
             case VisualThemeParameter.Random:
-                VisualTheme[] themesAll =
+                List<VisualTheme> themes_random = new List<VisualTheme>();
+                if (environmentParameters.use_ancient)
+                    themes_random.Add(VisualTheme.Ancient);
+                if (environmentParameters.use_moorish)
+                    themes_random.Add(VisualTheme.Moorish);
+                if (environmentParameters.use_industrial)
+                    themes_random.Add(VisualTheme.Industrial);
+                if (environmentParameters.use_modern)
+                    themes_random.Add(VisualTheme.Modern);
+                if (environmentParameters.use_future)
+                    themes_random.Add(VisualTheme.Future);
+                if (themes_random.Count < 1)
                 {
-                    VisualTheme.Ancient, VisualTheme.Moorish, VisualTheme.Industrial,
-                    VisualTheme.Modern, VisualTheme.Future
-                };
-                return themesAll[Random.Range(0, 5)];
+                    Debug.LogError("At least one visual theme has to be enabled to make use of VisualThemeParameter.Random.");
+                }
+                return themes_random[Random.Range(0, themes_random.Count)];
             default:
             {
                 return VisualTheme.Ancient;


### PR DESCRIPTION
If `visual-theme` is set to 2 (i.e. random ordering of themes), the reset parameters

``` 
use-ancient
use-moorish
use-industrial
use-modern
use-future
```

can now be set to 0 or 1 to exclude or include them (default is 1).
Additionally, default reset parameters are now set via the inspector.

The function SetDefaultEnvironmentParameters() (ObstacleTowerManager.cs:69) does not have any references so that should be removable.