### PR TITLE
Fix reset parameters

### DIFF
--- a/Assets/ObstacleTower/Scripts/FloorLogic/FloorBuilder.cs
+++ b/Assets/ObstacleTower/Scripts/FloorLogic/FloorBuilder.cs
@@ -89,6 +89,7 @@ public class FloorBuilder : MonoBehaviour
         {
             // Using System.Random to choose tower number so we don't end up choosing based on
             // the previously fixed seed for UnityEngine.Random.
+            floorGenerator.SetEnvironmentParams(environmentParameters);
             towerNumber = new System.Random().Next(ObstacleTowerManager.MaxSeed);
             lastTowerNumber = towerNumber;
             floors = floorGenerator.GenerateAllFloors(towerNumber, totalFloors);


### PR DESCRIPTION
This fixes my issue on https://github.com/Unity-Technologies/obstacle-tower-env/issues/118

I just call `floorGenerator.SetEnvironmentParams(environmentParameters);` in FloorBuilder.cs for not fixed towers as well.
I'm not sure if something else caused this issue, because I did not encounter this problem on the previous version.