### PR TITLE
Added a reset parameter that toggles the training and inference modes.

### DIFF
--- a/Assets/ObstacleTower/Scenes/Procedural.unity
+++ b/Assets/ObstacleTower/Scenes/Procedural.unity
@@ -910,7 +910,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   floor: {fileID: 883513242}
-  InferenceOn: 0
+  playMode: 0
+  trainMode: 1
   towerSeed: -1
   startingFloor: 0
   totalFloors: 100

--- a/Assets/ObstacleTower/Scripts/AgentLogic/EnvironmentParameters.cs
+++ b/Assets/ObstacleTower/Scripts/AgentLogic/EnvironmentParameters.cs
@@ -8,6 +8,7 @@ using System;
 [Serializable]
 public struct EnvironmentParameters
 {
+    public bool trainMode;
     public LightingType lightingType;
     public AgentPerspective agentPerspective;
     public VisualThemeParameter themeParameter;
@@ -19,7 +20,8 @@ public struct EnvironmentParameters
 
     public bool Compare(EnvironmentParameters otherParams)
     {
-        var equality = lightingType == otherParams.lightingType && 
+        var equality = trainMode == otherParams.trainMode &&
+                        lightingType == otherParams.lightingType && 
                         agentPerspective == otherParams.agentPerspective &&
                         themeParameter == otherParams.themeParameter &&
                         allowedRoomModules == otherParams.allowedRoomModules &&

--- a/Assets/ObstacleTower/Scripts/GameModeManager.cs
+++ b/Assets/ObstacleTower/Scripts/GameModeManager.cs
@@ -26,12 +26,12 @@ public class GameModeManager : MonoBehaviour
         {
             Debug.Log("In play mode");
             agent.GetComponent<BehaviorParameters>().BehaviorType = BehaviorType.HeuristicOnly;
-            academy.InferenceOn = true;
+            academy.playMode = true;
         }
         else
         {
             agent.GetComponent<BehaviorParameters>().BehaviorType = BehaviorType.Default;
-            academy.InferenceOn = false;
+            academy.playMode = false;
         }
         academy.enabled = true;
         agent.enabled = true;


### PR DESCRIPTION
Added a reset parameter that toggles the training and inference modes.
Renamed InferenceOn to playMode.
Removed SetDefaultEnvironmentParameters(), because it is not used.

This fixes #26, but needs to be reflected in the env repo as well.