### PR TITLE
Fix sparse reward function

### DIFF
--- a/Assets/ObstacleTower/Scripts/AgentLogic/ObstacleTowerAgent.cs
+++ b/Assets/ObstacleTower/Scripts/AgentLogic/ObstacleTowerAgent.cs
@@ -170,7 +170,7 @@ public class ObstacleTowerAgent : Agent
             DoorLogic doorController = col.transform.GetComponent<DoorLogic>();
             if (doorController)
             {
-                doorController.TryOpenDoor();
+                doorController.TryOpenDoor(this);
             }
         }
     }
@@ -182,7 +182,7 @@ public class ObstacleTowerAgent : Agent
             DoorLogic doorController = col.transform.GetComponent<DoorLogic>();
             if (doorController)
             {
-                doorController.TryCloseDoor();
+                doorController.TryCloseDoor(this);
             }
         }
     }

--- a/Assets/ObstacleTower/Scripts/ModuleLogic/DoorLogic.cs
+++ b/Assets/ObstacleTower/Scripts/ModuleLogic/DoorLogic.cs
@@ -60,13 +60,13 @@ public class DoorLogic : MonoBehaviour
     {
         open = false;
         animator.Play(clips[1]);
-        agent.AddReward(-0.1f);
+        if(agent.denseReward) agent.AddReward(-0.1f);
     }
 
     private void OpenDoor(ObstacleTowerAgent agent)
     {
         animator.Play(clips[0]);
         open = true;
-        agent.AddReward(0.1f);
+        if (agent.denseReward)  agent.AddReward(0.1f);
     }
 }

--- a/Assets/ObstacleTower/Scripts/ModuleLogic/DoorLogic.cs
+++ b/Assets/ObstacleTower/Scripts/ModuleLogic/DoorLogic.cs
@@ -11,7 +11,6 @@ public class DoorLogic : MonoBehaviour
     public Material openDoor;
     public GameObject door;
     private Animation animator;
-    KeyController keyController;
     private List<string> clips;
 
     private void Start()
@@ -24,7 +23,7 @@ public class DoorLogic : MonoBehaviour
         }
     }
 
-    public void TryOpenDoor()
+    public void TryOpenDoor(ObstacleTowerAgent agent)
     {
         if (!open)
         {
@@ -32,43 +31,42 @@ public class DoorLogic : MonoBehaviour
             || door.CompareTag("lockedDoorPuzzle") ||
             door.CompareTag("lockedDoorLever"))
             {
-                OpenDoor();
+                OpenDoor(agent);
             }
 
             if (door.CompareTag("lockedDoorKey"))
             {
-                keyController = FindObjectOfType<KeyController>();
-                if (keyController)
+                if (agent.keyController)
                 {
-                    if (keyController.currentNumberOfKeys > 0)
+                    if (agent.keyController.currentNumberOfKeys > 0)
                     {
-                        keyController.UseKey();
-                        OpenDoor();
+                        agent.keyController.UseKey();
+                        OpenDoor(agent);
                     }
                 }
             }
         }
     }
 
-    public void TryCloseDoor()
+    public void TryCloseDoor(ObstacleTowerAgent agent)
     {
         if (open && door.CompareTag("lockedDoorLever"))
         {
-            CloseDoor();
+            CloseDoor(agent);
         }
     }
 
-    private void CloseDoor()
+    private void CloseDoor(ObstacleTowerAgent agent)
     {
         open = false;
         animator.Play(clips[1]);
-        GameObject.FindWithTag("agent").GetComponent<ObstacleTowerAgent>().AddReward(-0.1f);
+        agent.AddReward(-0.1f);
     }
 
-    private void OpenDoor()
+    private void OpenDoor(ObstacleTowerAgent agent)
     {
         animator.Play(clips[0]);
         open = true;
-        GameObject.FindWithTag("agent").GetComponent<ObstacleTowerAgent>().AddReward(0.1f);
+        agent.AddReward(0.1f);
     }
 }

--- a/Assets/ObstacleTower/Scripts/ModuleLogic/PushBlockController.cs
+++ b/Assets/ObstacleTower/Scripts/ModuleLogic/PushBlockController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Unity.MLAgents;
+using UnityEngine;
 
 /// <summary>
 /// Responsible for determining whether block puzzle has been solved.
@@ -38,7 +39,8 @@ public class PushBlockController : MonoBehaviour
             foreach (var component in doorControllers)
             {
                 var door = (DoorLogic) component;
-                door.TryOpenDoor();
+                var agent = transform.root.GetComponent<FloorBuilder>().agent.GetComponent<ObstacleTowerAgent>();
+                door.TryOpenDoor(agent);
             }
         }
     }


### PR DESCRIPTION
According to the sparse reward function as stated by the paper, the agent shall only receive a reward for completing a floor. However, the current state is that the door rewards are signaled for both reward functions. This PR fixes the sparse reward function.

A further commit replaces the Find() method calls inside the door logic, which should make the code more efficient. That improvement is probably not noticeable, but still these methods are seen as a bad habit.