### PR TITLE
Agent camera sensor is now set to 168x168 instead of 84x84

### DIFF
--- a/Assets/ObstacleTower/Scenes/Procedural.unity
+++ b/Assets/ObstacleTower/Scenes/Procedural.unity
@@ -669,8 +669,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Camera: {fileID: 1582957648}
   m_SensorName: CameraSensor
-  m_Width: 84
-  m_Height: 84
+  m_Width: 168
+  m_Height: 168
   m_Grayscale: 0
   m_Compression: 1
 --- !u!114 &571992315


### PR DESCRIPTION
Fixes [https://github.com/Unity-Technologies/obstacle-tower-env/issues/126](https://github.com/Unity-Technologies/obstacle-tower-env/issues/126)